### PR TITLE
Replace serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1341,19 +1341,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1568,7 +1555,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "serde_yaml",
+ "serde_json",
  "time",
  "tracing",
  "tracing-actix-web",
@@ -1708,12 +1695,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ maplit = "~1.0"
 regex = "~1.10"
 reqwest = { version = "~0.12", features = [ "rustls-tls" ], default-features = false }
 serde = { version = "~1.0", features = [ "derive" ] }
-serde_yaml = "~0.9"
+serde_json = "~1.0.115"
 time = "~0.3.34"
 tracing = "~0.1.40"
 tracing-actix-web = "~0.7.10"

--- a/release.sh
+++ b/release.sh
@@ -1,14 +1,9 @@
 #!/bin/sh
 
 set -e
-
-#export ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR=/c/SysGCC/raspberry/arm-linux-gnueabihf/sysroot/usr/lib/arm-linux-gnueabihf
-#export ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR=/c/SysGCC/raspberry/arm-linux-gnueabihf/sysroot/usr/include/openssl
-export PATH=/c/SysGCC/raspberry/bin:/c/SysGCC/raspberry/arm-linux-gnueabihf/bin:${PATH}
-
 set -x
 
 cargo test
 cargo zigbuild --release --target aarch64-unknown-linux-gnu
-scp conf.yaml target/aarch64-unknown-linux-gnu/release/tomato-exporter gilneas:~
-ssh gilneas -- "chmod +x ~/tomato-exporter && sudo mv ~/tomato-exporter /usr/local/bin/tomato_exporter && sudo mv ~/conf.yaml /etc/tomato-exporter/conf.yaml && sudo systemctl restart tomato_exporter"
+scp conf.json target/aarch64-unknown-linux-gnu/release/tomato-exporter gilneas:~
+ssh gilneas -- "chmod +x ~/tomato-exporter && sudo mv ~/tomato-exporter /usr/local/bin/tomato_exporter && sudo mv ~/conf.json /etc/tomato-exporter/conf.json && sudo systemctl restart tomato_exporter"

--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,6 @@ export PATH=/c/SysGCC/raspberry/bin:/c/SysGCC/raspberry/arm-linux-gnueabihf/bin:
 set -x
 
 cargo test
-cargo build --release --target armv7-unknown-linux-gnueabihf
-scp conf.yaml target/armv7-unknown-linux-gnueabihf/release/tomato-exporter gilneas:~
+cargo zigbuild --release --target aarch64-unknown-linux-gnu
+scp conf.yaml target/aarch64-unknown-linux-gnu/release/tomato-exporter gilneas:~
 ssh gilneas -- "chmod +x ~/tomato-exporter && sudo mv ~/tomato-exporter /usr/local/bin/tomato_exporter && sudo mv ~/conf.yaml /etc/tomato-exporter/conf.yaml && sudo systemctl restart tomato_exporter"

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 pub fn load_conf(path: String) -> Config {
     let conf_str = fs::read_to_string(path).expect("Unable to find config file");
-    let conf: Config = serde_yaml::from_str(conf_str.as_str()).expect("Unable to load config file");
+    let conf: Config = serde_json::from_str(conf_str.as_str()).expect("Unable to load config file");
     conf
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ extern crate futures;
 extern crate maplit;
 extern crate regex;
 extern crate reqwest;
-extern crate serde_yaml;
+extern crate serde_json;
 extern crate tracing;
 extern crate tracing_actix_web;
 extern crate tracing_log;


### PR DESCRIPTION
Now that `serde_yaml` has been archived (see https://github.com/dtolnay/serde-yaml/releases/tag/0.9.34), move from using YAML to JSON for the config file for the exporter so we can use a library that is maintained (and a config language that is much more sane).